### PR TITLE
set screen-256color as default terminal

### DIFF
--- a/ide/Containerfile
+++ b/ide/Containerfile
@@ -9,6 +9,7 @@ RUN dnf clean all && \
 ENV GOPATH /root/go
 ENV GOBIN $GOPATH/bin
 ENV PATH $GOBIN:$PATH
+ENV TERM "screen-256color"
 
 # create emacs directories
 RUN mkdir -p ~/.emacs.d/lisp \


### PR DESCRIPTION
when using emacs with screen, the <esc>
keyboard does work and maps to <select>, this happens on default TERM, changing it to screen-256color fixes the issue